### PR TITLE
Pass the popover element to the content function

### DIFF
--- a/src/jquery.webui-popover.js
+++ b/src/jquery.webui-popover.js
@@ -370,7 +370,7 @@
             } else if (!this.content) {
                 var content = '';
                 if ($.isFunction(this.options.content)) {
-                    content = this.options.content.apply(this.$element[0], arguments);
+                    content = this.options.content.apply(this.$element[0], [this]);
                 } else {
                     content = this.options.content;
                 }


### PR DESCRIPTION
getContent() seems to never be called with arguments, so it looks like the argument parameter can be removed here.

Adding [this] to the parameters has the benefit that one can later on change the content of the popover.

In the content function, store it:

function contentFunction(popover) { myPopver=popover;  return "...one moment...";}

And then later on you can change the content like this:

myPopover.setContent("Hello, this is some fresh content!");
myPopover.displayContent();

This solves issues like this one:
https://github.com/sandywalker/webui-popover/issues/41
Where you want to wait for something (in this case images loading) and only then display new content.